### PR TITLE
Fixed error with saving DiagramCaretaker.

### DIFF
--- a/src/Diagram/Diagram.java
+++ b/src/Diagram/Diagram.java
@@ -22,7 +22,6 @@ public class Diagram {
    private HashMap<String, Class> classList;
    @Expose
    private HashMap<String, Relationship> relationshipList;
-   @Expose
    private DiagramCaretaker caretaker;
    @Expose
    private GUIDiagramProjectDto coordinates;
@@ -265,6 +264,10 @@ public class Diagram {
 
    public DiagramCaretaker getCaretaker() {
       return this.caretaker;
+   }
+
+   public void setCaretaker(DiagramCaretaker caretaker){
+      this.caretaker = caretaker;
    }
 
    public void createSnapshot() {

--- a/src/SaveLoadSystem/SaveLoadSystem.java
+++ b/src/SaveLoadSystem/SaveLoadSystem.java
@@ -1,6 +1,7 @@
 package SaveLoadSystem;
 
 import Diagram.Diagram;
+import Diagram.DiagramCaretaker;
 import com.google.gson.*;
 import javafx.geometry.Point2D;
 
@@ -128,6 +129,8 @@ public class SaveLoadSystem {
                         .excludeFieldsWithoutExposeAnnotation()
                         .create();
                 diagram = gson.fromJson(fileReader, Diagram.class);
+                diagram.setCaretaker(new DiagramCaretaker());
+                diagram.createSnapshot();
                 fileReader.close();
                 return diagram;
             } catch (FileNotFoundException e) {


### PR DESCRIPTION
1. Removed DiagramCaretaker from the list of objects saved from a Diagram.
2. Diagram creates a new instance of a DiagramCaretaker when loaded.
3. Diagram creates a snapshot of itself during the load so that the first instance of Undo/Redo starts with the project in its current state after loading.